### PR TITLE
Display more detail about progress with progress bar.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -434,7 +434,6 @@ fn find_cargo_projects_task(
     let mut has_target = false;
 
     pb.set_message(format!("looking at: {}", job.path.display()));
-    pb.inc(1);
 
     let read_dir = match job.path.read_dir() {
         Ok(it) => it,
@@ -474,7 +473,6 @@ fn find_cargo_projects_task(
         results.send(ProjectDir(job.path, has_target)).unwrap();
     }
     pb.set_message("waiting...");
-    pb.inc(1);
 }
 
 #[derive(Clone, Debug)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,22 +297,19 @@ fn main() {
         }
     }
 
-    let failed_cleanups = selected
-        .iter()
-        .filter_map(|tgt| {
-            clean_progress.inc(1);
-            remove_dir_all::remove_dir_all(&tgt.project_path.join("target"))
-                .err()
-                .map(|e| (tgt.clone(), e))
-        })
-        .collect::<Vec<_>>();
+    let failed_cleanups = selected.iter().filter_map(|tgt| {
+        clean_progress.inc(1);
+        remove_dir_all::remove_dir_all(&tgt.project_path.join("target"))
+            .err()
+            .map(|e| (tgt.clone(), e))
+    });
 
     clean_progress.finish();
 
     // The current leftover size calculation assumes that a failed deletion didn't delete anything.
     // This will not be true in most cases as a recursive deletion might delet stuff before failing.
     let mut leftover_size = 0;
-    for (tgt, e) in &failed_cleanups {
+    for (tgt, e) in failed_cleanups {
         leftover_size += tgt.size;
         println!("Failed to clean {}", pretty_format_path(&tgt.project_path));
         println!("Error: {}", e);


### PR DESCRIPTION
last patch, based on https://github.com/dnlmlr/cargo-clean-all/pull/15 to avoid conflicts.

It's NITS (and couple of perfs improvements that most probably don't matter).

The current progress bar tell nothing about the process what is done, so it's hard to know how much longer it'll take, and if it's normal if it's slow or not, this PR address that by splitting the progress bar in 2.

In the first part, while looking for rust projects, it display the current file being looked-up for each thread:
<img width="1200" alt="image" src="https://github.com/dnlmlr/cargo-clean-all/assets/56031107/d9323ff0-e049-4930-9b0c-f33cf95ff22c">
Note: Threads are not necessarily in the right order, since started at the same time, could be fixed by simply removing the number
Afterwards, it displays which rust project it's computing the target size of:
![xx](https://github.com/dnlmlr/cargo-clean-all/assets/56031107/aa9a82f6-80f5-44b7-853b-f3105def64cc)
Note: the wording was changed to `Computing size of target/ for project` afterwards.


Since both parts can take a significant time (seconds), it's worthwhile to display the current progress. And that way if something hangs or go wrong, it's much easier to pinpoint where it happened.